### PR TITLE
Store session token timestamp and don't check validity if less than 10s old

### DIFF
--- a/data_types/SessionToken/config.json
+++ b/data_types/SessionToken/config.json
@@ -20,6 +20,13 @@
         "name" : "Text"
       },
       "isLabel" : false
+    }, {
+      "name" : "timestamp",
+      "fieldType" : {
+        "exportId" : "Text",
+        "name" : "Text"
+      },
+      "isLabel" : false
     } ],
     "usesCode" : false
   }

--- a/lib/session-token.js
+++ b/lib/session-token.js
@@ -36,30 +36,52 @@ function getSessionToken(ellipsis, username, password) {
     })
   });
 }
+
+// not more than 10s old
+function isRecent(token) {
+  if (token.timestamp) {
+    const now = new Date();
+    const tokenTimestamp = new Date(token.timestamp);
+    return tokenTimestamp > new Date(now - 10000);
+  } else {
+    return false;
+  }
+}
   
 function isTokenValid(token, ellipsis) {
+  const shouldLogTiming = ellipsis.env.COLLIBRA_SHOULD_LOG_TIMING.toLowerCase() === "true";
   return new Promise((resolve, reject) => {
-    if (!token) { resolve(false); }
-    request({ 
-      url: apiBaseUrl(ellipsis) + "/auth/sessions/current",
-      json: true,
-      headers: { "Cookie": `JSESSIONID=${token.token}` }
-    }, (err, res, body) => {
-      if (err) {
-        reject(new ellipsis.Error(err.message, { userMessage: res.statusCode === 401 ?
-                                       "An error occurred. Your login credentials do not appear to be valid." :
-                                       "An unknown error occurred. Collibra may not be working at the moment."
-                                      }));
-      } else if (res.statusCode != 200) {
-        resolve(false);
-      } else {
-        resolve(true);
-      }
-    })
+    if (!token) { 
+      resolve(false); 
+    } else if (isRecent(token)) {
+      resolve(true);
+    } else {
+      request({ 
+        url: apiBaseUrl(ellipsis) + "/auth/sessions/current",
+        json: true,
+        time: shouldLogTiming,
+        headers: { "Cookie": `JSESSIONID=${token.token}` }
+      }, (err, res, body) => {
+        if (shouldLogTiming) {
+          console.log(`\nAPI call ${res.request.uri.href}\nElapsed time: ${res.elapsedTime}\n`);
+        }
+        if (err) {
+          reject(new ellipsis.Error(err.message, { userMessage: res.statusCode === 401 ?
+                                         "An error occurred. Your login credentials do not appear to be valid." :
+                                         "An unknown error occurred. Collibra may not be working at the moment."
+                                        }));
+        } else if (res.statusCode != 200) {
+          resolve(false);
+        } else {
+          resolve(true);
+        }
+      })
+    }
   });         
 }
 
 function getNewToken(ellipsis, login) {
+  const shouldLogTiming = ellipsis.env.COLLIBRA_SHOULD_LOG_TIMING.toLowerCase() === "true";
   return new Promise((resolve, reject) => {
     const data = {
       username: login.username,
@@ -73,6 +95,9 @@ function getNewToken(ellipsis, login) {
       body: data,
       jar: jar
     }, (err, res, body) => {
+      if (shouldLogTiming) {
+        console.log(`\nAPI call ${res.request.uri.href}\nElapsed time: ${res.elapsedTime}\n`);
+      }
       if (err || res.statusCode != 200) {
         const message = err && err.message || `Error ${res.statusCode}: ${res.statusMessage}`;
         reject(new ellipsis.Error(message, { userMessage: res.statusCode === 401 ?
@@ -98,6 +123,7 @@ function getSavedToken(ellipsis, login) {
         id
         token
         username
+        timestamp
       }
 
     }
@@ -146,12 +172,14 @@ function saveToken(token, username, ellipsis) {
         id
         token
         username
+        timestamp
       }
 
     }
   `;
 
-  const vars = { sessionToken: { token: token, username: username }, filter: { username: username } };
+  const timestamp = (new Date()).toString();
+  const vars = { sessionToken: { token: token, username: username, timestamp: timestamp }, filter: { username: username } };
   return storageApi.query({ query: mutation, variables: vars }).then(res => {
     if (res.data) {
       return res.data.createSessionToken;


### PR DESCRIPTION
This reduces the number of API calls to the current sessions endpoint a fair bit