### PR TITLE
Run "accept" task types

### DIFF
--- a/README
+++ b/README
@@ -1,0 +1,1 @@
+A set of workflows to help integrate a Collibra instance into chat, including linking discussions to Collibra, looking up and updating definitions, completing data steward workflows, and more.

--- a/README
+++ b/README
@@ -1,1 +1,0 @@
-A set of workflows to help integrate a Collibra instance into chat, including linking discussions to Collibra, looking up and updating definitions, completing data steward workflows, and more.

--- a/actions/discuss-issue-start/function.js
+++ b/actions/discuss-issue-start/function.js
@@ -3,7 +3,6 @@ function(issueId, ellipsis) {
 const formatAttribute = require('definition-helpers').textForAttribute;
 const EllipsisApi = require('ellipsis-api');
 const api = new EllipsisApi(ellipsis);
-
 const username = ellipsis.userInfo.messageInfo.details.name;
 const permalink = ellipsis.userInfo.messageInfo.permalink;
 CollibraApi(ellipsis).then(collibra => {
@@ -15,7 +14,7 @@ CollibraApi(ellipsis).then(collibra => {
       args: [
         { name: "commentId", value: saved.id }
       ],
-      thread: ellipsis.userInfo.messageInfo.thread
+      thread: ellipsis.event.message ? ellipsis.event.message.thread : undefined
     }).then(() => {
       ellipsis.success({ 
         issueLink: collibra.linkFor("asset", issueId),

--- a/actions/discuss-issue-trigger/function.js
+++ b/actions/discuss-issue-trigger/function.js
@@ -1,5 +1,5 @@
 function(issue, ellipsis) {
-  ellipsis.success("", {
+  ellipsis.success("OK, let's get started…", {
   next: {
     actionName: "discuss-issue",
     args: [{ name: "issue", value: issue.id }]

--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
   "name" : "Collibra",
-  "exportId" : "dLk-cTVBSxeNuLsgHo2qxg",
+  "exportId" : "RoNXoo-0TrijjZP1F2f3Gg",
   "icon" : "🔮",
   "requiredAWSConfigs" : [ ],
   "requiredOAuthApiConfigs" : [ ],

--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
   "name" : "Collibra",
-  "exportId" : "RoNXoo-0TrijjZP1F2f3Gg",
+  "exportId" : "dLk-cTVBSxeNuLsgHo2qxg",
   "icon" : "🔮",
   "requiredAWSConfigs" : [ ],
   "requiredOAuthApiConfigs" : [ ],

--- a/lib/asset-helpers.js
+++ b/lib/asset-helpers.js
@@ -43,7 +43,7 @@ function respondWithChosenAssetOrAddNew(ellipsis, asset, options) {
     CollibraApi(ellipsis).then(api => {
       api.findAssetTypeIdNamed(options.assetTypeName).then(assetTypeId => {
         const newOptions = Object.assign({}, options, { assetTypeId: assetTypeId });
-        addNewAsset(ellipsis, asset, newOptions).then(ellipsis.success);
+        addNewAsset(ellipsis, asset, newOptions);
       });
     }); 
   } else {


### PR DESCRIPTION
- Allow `accept` as a task type, since it's the same as `vote`
- properly display the task type string in case of errors.